### PR TITLE
Feature/webcms 4277 collective.ckeditor wieder vervollstandigen

### DIFF
--- a/src/collective/ckeditor/browser/ckeditorview.py
+++ b/src/collective/ckeditor/browser/ckeditorview.py
@@ -190,11 +190,10 @@ class CKeditorView(BrowserView):
         TODO : improve it with a control panel
         """
         css_jsList = []
-        # retrieve plone.htmlhead.links viewlet manager
-        view = View(self.portal, self.request)
+        # retrieve plone.htmlhead.links viewlet manager using the current view
         manager_name = 'plone.htmlhead.links'
-        # viewlet managers are found by Multi-Adapter lookup
-        adapter = queryMultiAdapter((self.portal, self.request, view), IViewletManager, manager_name, default=None)
+        # viewlet managers are found by Multi-Adapter lookup on Request and a view
+        adapter = queryMultiAdapter((self.portal, self.request, self), IViewletManager, manager_name, default=None)
         if adapter:
             # TODO: can we lookup the viewlet directly? (what if it was transferred to another manager?)
             styles_viewlet = adapter.get("plone.resourceregistries.styles")

--- a/src/collective/ckeditor/browser/ckeditorview.py
+++ b/src/collective/ckeditor/browser/ckeditorview.py
@@ -402,6 +402,9 @@ class CKeditorView(BrowserView):
         return params_js_string
 
     def getCK_vars(self):
+        request = self.request
+        response = request.RESPONSE
+        response.setHeader('Content-Type', 'application/x-javascript')
         return CK_VARS_TEMPLATE % {'portal_url': self.portal_url}
 
     def getCustomTemplatesConfig(self, customTemplates):

--- a/src/collective/ckeditor/browser/statics/ckeditor_plone.js
+++ b/src/collective/ckeditor/browser/statics/ckeditor_plone.js
@@ -82,12 +82,12 @@ if ( window.CKEDITOR )
 
 		$(document).ready(function() {
             /* Setting up jsi18n message factory for ckeditor with jsi18n (from mockup) via requirejs.
-                Use a fallback for plone 4 without require but
+                Use a fallback for plone 4 without require but jarn dependency.
             */
             try {
                 require(['mockup-i18n'], function(I18N) {
                     if (typeof(i18n) === 'undefined') {
-                        i18n = new I18N()
+                        i18n = new I18N();
                     }
                     init(i18n);
                 });
@@ -96,13 +96,13 @@ if ( window.CKEDITOR )
                 try {
                     init(jarn.i18n);
                 } catch(e) {
-                    console.log('failed to load i18n');
+                    console.log('Failed to load i18n via mockup as well as jarn fallback.');
                 }
             }
 
             // Show a friendly compatibility message as soon as the page is loaded,
             // for those browsers that are not compatible with CKEditor.
-            if ( CKEDITOR.env.isCompatible )
+            if ( !CKEDITOR.env.isCompatible )
                 showCompatibilityMsg();
         });
 	})();

--- a/src/collective/ckeditor/browser/statics/ckeditor_plone.js
+++ b/src/collective/ckeditor/browser/statics/ckeditor_plone.js
@@ -64,7 +64,10 @@ if ( window.CKEDITOR )
 
 			html += '</p><p>' + ck_mf(locale.ckeditorStillUsable) + '</p>';
 
-			document.getElementById( 'alerts' ).innerHTML = html;
+			let alerts = document.getElementById( 'alerts' );
+            if (alerts) {
+                alerts.innerHTML = html;
+            }
 		};
 
         var init = function(i18n){

--- a/src/collective/ckeditor/browser/statics/ckeditor_plone.js
+++ b/src/collective/ckeditor/browser/statics/ckeditor_plone.js
@@ -7,6 +7,8 @@ if ( typeof console != 'undefined' )
 var ck_mf = function(m){
     return m;
 };
+// make sure i18n variable is global
+var i18n;
 
 var ck_locales = {
     "messagefactory": ck_mf,
@@ -85,7 +87,7 @@ if ( window.CKEDITOR )
             try {
                 require(['mockup-i18n'], function(I18N) {
                     if (typeof(i18n) === 'undefined') {
-                        var i18n = new I18N();
+                        i18n = new I18N()
                     }
                     init(i18n);
                 });
@@ -93,7 +95,7 @@ if ( window.CKEDITOR )
             catch(e) {
                 try {
                     init(jarn.i18n);
-                } catch (e) {
+                } catch(e) {
                     console.log('failed to load i18n');
                 }
             }

--- a/src/collective/ckeditor/browser/statics/ckeditor_plone.js
+++ b/src/collective/ckeditor/browser/statics/ckeditor_plone.js
@@ -67,26 +67,37 @@ if ( window.CKEDITOR )
 			document.getElementById( 'alerts' ).innerHTML = html;
 		};
 
+        var init = function(i18n){
+            let lang = $('html').attr('lang');
+            // get the translation tool catalog for the given language and domain
+            i18n.loadCatalog('collective.ckeditor', lang);
+            // initialize the message factory
+            ck_mf = i18n.MessageFactory('collective.ckeditor', lang);
+        }
+
 		$(document).ready(function() {
-            /* Setting up jsi18n message factory for ckeditor with jsi18n (from mockup) */
-            require(['mockup-i18n'], function(I18N) {
-                try {
+            /* Setting up jsi18n message factory for ckeditor with jsi18n (from mockup) via requirejs.
+                Use a fallback for plone 4 without require but
+            */
+            try {
+                require(['mockup-i18n'], function(I18N) {
                     if (typeof(i18n) === 'undefined') {
                         var i18n = new I18N();
                     }
-                    var lang = $('html').attr('lang');
-                    // get the translation tool catalog for the given language and domain
-                    i18n.loadCatalog('collective.ckeditor', lang);
-                    // let's initialize message factory
-                    ck_mf = i18n.MessageFactory('collective.ckeditor', lang);
+                    init(i18n);
+                });
+            }
+            catch(e) {
+                try {
+                    init(jarn.i18n);
                 } catch (e) {
                     console.log('failed to load i18n');
                 }
-            });
+            }
 
             // Show a friendly compatibility message as soon as the page is loaded,
             // for those browsers that are not compatible with CKEditor.
-            if ( !CKEDITOR.env.isCompatible )
+            if ( CKEDITOR.env.isCompatible )
                 showCompatibilityMsg();
         });
 	})();


### PR DESCRIPTION
1) Workover requireJS / mockup / jarn in a more compatible way
2) bring back the inner css for the ckeditor canvas (iframe) by removing the portal_css parts in the view and replacing it with equally specific internal stuff from the styles viewlet that uses the new registry. Could need some improvement. 