### PR TITLE
Fix upgrade for ckeditor_properties

### DIFF
--- a/src/collective/ckeditor/profiles/default/metadata.xml
+++ b/src/collective/ckeditor/profiles/default/metadata.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <metadata>
-  <version>4350</version>
+  <version>4360</version>
   <dependencies>
     <dependency>profile-collective.plonefinder:default</dependency>
     <dependency>profile-collective.quickupload:default</dependency>

--- a/src/collective/ckeditor/upgrades.py
+++ b/src/collective/ckeditor/upgrades.py
@@ -117,14 +117,16 @@ def to_registry(context):
     # clean up only if there are things to clean up
     if "ckeditor_properties" in ptool:
         props = ptool.ckeditor_properties
-        api.portal.set_registry_record(
-            "collective.ckeditor.browser.ckeditorsettings.ICKEditorSchema.forcePasteAsPlainText",
-            props.forcePasteAsPlainText
-        )
+        if hasattr(props, "forcePasteAsPlainText"):
+            api.portal.set_registry_record(
+                "collective.ckeditor.browser.ckeditorsettings.ICKEditorSchema.forcePasteAsPlainText",
+                props.forcePasteAsPlainText
+            )
 
-        api.portal.set_registry_record(
-            "collective.ckeditor.browser.ckeditorsettings.ICKEditorSchema.skin",
-            props.skin
-        )
+        if hasattr(props, "skin"):
+            api.portal.set_registry_record(
+                "collective.ckeditor.browser.ckeditorsettings.ICKEditorSchema.skin",
+                props.skin
+            )
 
         ptool.manage_delObjects("ckeditor_properties")


### PR DESCRIPTION
Makes the upgrade path safer. Not all properties exist in certain setups.